### PR TITLE
Fix for incompatible default values.

### DIFF
--- a/PolicyPlus/XmlExtensions.vb
+++ b/PolicyPlus/XmlExtensions.vb
@@ -1,4 +1,5 @@
-﻿Imports System.Runtime.CompilerServices
+Imports System.ComponentModel
+Imports System.Runtime.CompilerServices
 Imports System.Xml
 Public Module XmlExtensions
     ' Convenience methods for parsing XML in AdmxFile and AdmlFile
@@ -6,6 +7,11 @@ Public Module XmlExtensions
         If Node.Attributes(Attribute) Is Nothing Then Return Nothing Else Return Node.Attributes(Attribute).Value
     End Function
     <Extension> Public Function AttributeOrDefault(Node As XmlNode, Attribute As String, DefaultVal As Object) As Object
-        If Node.Attributes(Attribute) Is Nothing Then Return DefaultVal Else Return Node.Attributes(Attribute).Value
+        If Node.Attributes(Attribute) Is Nothing Then Return DefaultVal
+        Dim converter As TypeConverter = TypeDescriptor.GetConverter(DefaultVal.GetType())
+        If converter.IsValid(Node.Attributes(Attribute).Value) Then
+            Return converter.ConvertFromString(Node.Attributes(Attribute).Value)
+        End If
+        Return DefaultVal
     End Function
 End Module


### PR DESCRIPTION
Some admx files have incompatible default values (most often an empty string "" for numerical fields).  PolicyPlus fails when trying to parse those files.

This fix should take care of all situations when the specified default value cannot be converted to the field's type.  

You can find some examples of admx files with empty strings in numeric fields in the [Office 2016 administrative templates](http://www.microsoft.com/en-ca/download/details.aspx?id=49030)